### PR TITLE
Change tile grid cell conversion in render function

### DIFF
--- a/src/xminigrid/rendering/rgb_render.py
+++ b/src/xminigrid/rendering/rgb_render.py
@@ -250,7 +250,7 @@ def render(
                 agent_direction = None
 
             tile_img = render_tile(
-                tile=tuple(grid[y, x]),
+                tile=tuple(grid[y, x].tolist()),
                 agent_direction=agent_direction,
                 highlight=highlight_mask[y, x],
                 tile_size=int(tile_size),


### PR DESCRIPTION
Changed the tuple conversion in the `render_tile` call of `render` as following the notebook examples was causing ""unhashable type: 'ArrayImpl'"" on jax version 0.4.25

Not sure if there is some other cause of this / the example notebook is outdated in someway (in particular, the Rules & Goals section).